### PR TITLE
Feature detect landmarks script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/detect_landmarks.py
+++ b/detect_landmarks.py
@@ -1,0 +1,83 @@
+import os
+from options.test_options import TestOptions
+from mtcnn import MTCNN
+import cv2
+
+
+def get_data_path(root='custom_images'):
+    im_path = [os.path.join(root, i) for i in sorted(
+        os.listdir(root)) if i.endswith('png') or i.endswith('jpg')]
+    lm_path = [i.replace('png', 'txt').replace('jpg', 'txt') for i in im_path]
+    lm_path = [os.path.join(i.replace(i.split(
+        os.path.sep)[-1], ''), 'detections', i.split(os.path.sep)[-1]) for i in lm_path]
+
+    return im_path, lm_path
+
+
+def draw_landmark(source_image, keypoint, image_path, image_index):
+  # Draw the keypoint.
+  cv2.circle(source_image, keypoint, radius=8,
+             color=(0, 0, 255), thickness=-1)
+  cv2.imshow('Image #' + str(image_index) + ' - ' +
+             image_path[image_index], source_image)
+
+
+def main(opt, name='custom_images'):
+  im_path, lm_path = get_data_path(name)
+
+  for i in range(len(im_path)):
+    print('Detect landmarks:', i, im_path[i])
+
+    # source_image = cv2.cvtColor(cv2.imread(im_path[i]), cv2.COLOR_BGR2RGB)
+    source_image = cv2.imread(im_path[i])
+
+    # Launch faces detector only if there is no existing landmarks file for
+    # this image.
+    if os.path.isfile(lm_path[i]):
+      # Get the keypoints from the landmark file.
+      with open(lm_path[i], 'r') as landmarks_file:
+        lines = landmarks_file.readlines()
+        landmarks_file.close()
+
+        for line in lines:
+          # Get the keypoint from each line and convert it in a floats tuple.
+          keypointsStrList = line.strip().split('\t')
+
+          # `cv2.circle()` expects a tuple of integers as the `center`
+          # parameter, so we need to remove the float part of each
+          # coordinate string.
+          keypoint = (int(keypointsStrList[0].split('.')[0]),
+                      int(keypointsStrList[1].split('.')[0]))
+
+          # Only for debugging purposes.
+          print('Keypoint type:' + str(type(keypoint)))
+          for coordinate in keypoint:
+            print('Keypoint coordinate value:' +
+                  str(coordinate) + '; type:' + str(type(coordinate)))
+
+          draw_landmark(source_image, keypoint, im_path, i)
+    else:
+      detector = MTCNN()
+      detected_faces = detector.detect_faces(source_image)
+      print('Detected Faces: ', detected_faces)
+
+      keypoints = detected_faces[0]['keypoints'].values()
+      landmarks = ''
+
+      for keypoint in keypoints:
+        # Append the current keypoint to the output string `landmarks`.
+        landmarks += str(keypoint[0]) + '.0\t' + str(keypoint[1]) + '.0\n'
+
+        draw_landmark(source_image, keypoint, im_path, i)
+
+        with open(lm_path[i], 'w') as landmarks_file:
+          landmarks_file.write(landmarks)
+          landmarks_file.close()
+
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+  opt = TestOptions().parse()
+  main(opt, opt.img_folder)


### PR DESCRIPTION
Merge `feature-detect-landmarks-script` into `RC1`.

`detect_landmarks` is a script to batch detect landmarks of custom images using MTCNN library.

NOTE: custom images directory and `detections` subdirectory have to be manually created before to launch the script.
TODO: I plan to add the creation code for custom images and `detections` directories.

At the end of each image landmarks detection the script present the image in a OpenCV view with its landmarks drawn over it for debug purposes. User can press any key to close the image view and jump to the next one.

TODO: probably it would be better to detect them all in once and present them at the end of the process. Also it would be probably useful to provida an option to fully disable debug image presentation.

TODO: MTCNN seems not able to detect float values; maybe we should use dlib instead.